### PR TITLE
Add map data filtering based on custom marks

### DIFF
--- a/hugo/assets/js/map.js
+++ b/hugo/assets/js/map.js
@@ -2,8 +2,14 @@
 // OSM tiles
 // Using CARTO tile server, see: https://carto.com/location-data-services/basemaps/
 const OSM_URL = 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png';
+
+var url = new URL(window.location.href);
+var mark = url.searchParams.get("mark");
+var all_data = url.searchParams.get("all");
+
+
 // SRS tiles
-const SRS_TILES_URL = '/api/v1/tiles/{z}/{x}/{y}';
+const SRS_TILES_URL = '/api/v1/tiles/{z}/{x}/{y}/' + (mark == undefined ? "" : mark + "/") + (all_data == undefined? "" : all_data + "/");
 // SRS data used for PPE visualization
 const SRS_DATA_BASE_URL = '';
 // Geocoder


### PR DESCRIPTION
It makes possible to append _mark_ and _all_ get parameters to the http://smartroadsense.uniurb.it/data/map/ URL and to pass them through to backend services.

- _mark_ (e.g., http://smartroadsense.uniurb.it/it/data/map/?mark=test-1) to show only those raw data points collected in the last 7 days and associated with tracks marked with` "clientMark":"Test-1"` (it's case insensitive)
- _all_ (e.g.,  http://smartroadsense.uniurb.it/it/data/map/?mark=test-1&all=True) to also show data points older than 7 days (only work in conjunction with the _mark_ parameter)